### PR TITLE
streamlit-option-menu 0.3.12 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "streamlit-option-menu" %}
+{% set version = "0.3.12" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: a954241cf188691f17072cf3ceb59e97f106f7492ddb5b79c4d42906758a5af2
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+  # s390x is missing streamlit
+  skip: true  # [py<36 or s390x]
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+  run:
+    - python
+    - streamlit >=0.63
+
+test:
+  imports:
+    - streamlit_option_menu
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/victoryhb/streamlit-option-menu
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: streamlit-option-menu is a simple Streamlit component.
+  description: |
+    streamlit-option-menu is a simple Streamlit component that 
+    allows users to select a single item from a list of options in a menu.
+  doc_url: https://github.com/victoryhb/streamlit-option-menu/blob/master/README.md
+  dev_url: https://github.com/victoryhb/streamlit-option-menu
+
+extra:
+  recipe-maintainers:
+    - psteyer


### PR DESCRIPTION
streamlit-option-menu 0.3.12 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4478](https://anaconda.atlassian.net/browse/PKG-4478) 
- [Upstream repository](https://github.com/victoryhb/streamlit-option-menu)

### Explanation of changes:

- initial package creation using `conda-skeleton`
- added skip for `s390x`
- no upstream tests; added basic `pip check`


[PKG-4478]: https://anaconda.atlassian.net/browse/PKG-4478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ